### PR TITLE
feat: Add Japanese localized RLM package with logging support

### DIFF
--- a/examples/ja/basic_usage_ja.py
+++ b/examples/ja/basic_usage_ja.py
@@ -54,14 +54,14 @@ def main():
     """Run basic RLM example."""
     rlm = RLM(
         model="gpt-4o",  # Use mini for cheaper testing
-        max_iterations=15
+        max_iterations=15,
+        temperature=0.7
     )
 
     query = "この文書によると、AI開発における主要なマイルストーンは何ですか？年代ごとにまとめてください。"
 
     try:
-        result = rlm.completion(query, long_document)
-        print(result)
+        rlm.completion(query, long_document)
 
     except Exception as e:
         print(f"Error: {e}")

--- a/examples/ja/basic_usage_ja.py
+++ b/examples/ja/basic_usage_ja.py
@@ -1,0 +1,83 @@
+"""Basic usage example for RLM."""
+
+import os
+import sys
+import warnings
+
+# Ignore Pydantic warnings from litellm
+warnings.filterwarnings("ignore", module="pydantic")
+
+# Add src to path to import rlm_ja
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../src')))
+
+from dotenv import load_dotenv
+from rlm_ja import RLM
+
+# Load environment variables from .env file
+load_dotenv()
+
+# Sample long document (Japanese translation of the original text)
+long_document = """
+人工知能の歴史
+
+はじめに
+過去数十年の間に、人工知能（AI）は理論的な概念から実用的な現実へと変化しました。
+この文書では、AI開発における主要なマイルストーンを探ります。
+
+1950年代：AIの誕生
+1950年、アラン・チューリングは「計算機と知性」を発表し、有名なチューリング・テストを導入しました。
+「人工知能」という用語は、1956年のダートマス会議でジョン・マッカーシー、マービン・ミンスキーらによって作られました。
+
+1960年代-1970年代：初期の楽観主義
+この時期、研究者たちはELIZA（1966年）のような初期のAIプログラムやエキスパートシステムを開発しました。
+しかし、計算能力の限界により、1970年代には最初の「AIの冬」が訪れました。
+
+1980年代-1990年代：エキスパートシステムとニューラルネットワーク
+1980年代にはエキスパートシステムが商業的に成功しました。
+1986年にはバックプロパゲーション・アルゴリズムによってニューラルネットワーク研究が活性化しました。
+
+2000年代-2010年代：機械学習の革命
+ビッグデータの台頭と強力なGPUにより、ディープラーニングのブレークスルーが可能になりました。
+2012年、AlexNetがImageNetコンペティションで優勝し、ディープラーニングの転換点となりました。
+
+2020年代：大規模言語モデル
+GPT-3（2020年）やChatGPT（2022年）は、前例のない言語理解能力を示しました。
+これらのモデルは何十億ものパラメータを持ち、膨大な量のテキストデータで訓練されています。
+
+結論
+AIは医療、交通、教育など数え切れないほどの分野で応用され、急速に進化し続けています。
+未来にはさらにエキサイティングな発展が約束されています。
+""" * 10  # Multiply to make it longer
+
+
+def main():
+    """Run basic RLM example."""
+    rlm = RLM(
+        model="gpt-4o",  # Use mini for cheaper testing
+        max_iterations=15
+    )
+
+    query = "この文書によると、AI開発における主要なマイルストーンは何ですか？年代ごとにまとめてください。"
+
+    try:
+        result = rlm.completion(query, long_document)
+        print(result)
+
+    except Exception as e:
+        print(f"Error: {e}")
+
+
+if __name__ == "__main__":
+    # Make sure to set your API key in .env file or as environment variable:
+    # OPENAI_API_KEY=sk-...
+
+    if not os.getenv("OPENAI_API_KEY"):
+        print("❌ Error: OPENAI_API_KEY not found!")
+        print()
+        print("Please set up your API key:")
+        print("  1. Copy .env.example to .env")
+        print("  2. Add your OpenAI API key to .env")
+        print("  3. Or run: python setup_env.py")
+        exit(1)
+
+    main()

--- a/src/rlm_ja/__init__.py
+++ b/src/rlm_ja/__init__.py
@@ -1,0 +1,14 @@
+"""Recursive Language Models for unbounded context processing."""
+
+from .core import RLM, RLMError, MaxIterationsError, MaxDepthError
+from .repl import REPLError
+
+__version__ = "0.1.0"
+
+__all__ = [
+    "RLM",
+    "RLMError",
+    "MaxIterationsError",
+    "MaxDepthError",
+    "REPLError",
+]

--- a/src/rlm_ja/core.py
+++ b/src/rlm_ja/core.py
@@ -1,0 +1,321 @@
+"""Core RLM implementation."""
+
+import asyncio
+import re
+from typing import Optional, Dict, Any, List
+
+import litellm
+
+from .types import Message
+from .repl import REPLExecutor, REPLError
+from .prompts import build_system_prompt
+from .parser import parse_response, is_final
+from .logger import get_logger
+
+class RLMError(Exception):
+    """Base error for RLM."""
+    pass
+
+
+class MaxIterationsError(RLMError):
+    """Max iterations exceeded."""
+    pass
+
+
+class MaxDepthError(RLMError):
+    """Max recursion depth exceeded."""
+    pass
+
+
+class RLM:
+    """Recursive Language Model."""
+
+    def __init__(
+        self,
+        model: str,
+        recursive_model: Optional[str] = None,
+        api_base: Optional[str] = None,
+        api_key: Optional[str] = None,
+        max_depth: int = 5,
+        max_iterations: int = 30,
+        _current_depth: int = 0,
+        **llm_kwargs: Any
+    ):
+        """
+        Initialize RLM.
+
+        Args:
+            model: Model name (e.g., "gpt-4o", "claude-sonnet-4", "ollama/llama3.2")
+            recursive_model: Optional cheaper model for recursive calls
+            api_base: Optional API base URL
+            api_key: Optional API key
+            max_depth: Maximum recursion depth
+            max_iterations: Maximum REPL iterations per call
+            _current_depth: Internal current depth tracker
+            **llm_kwargs: Additional LiteLLM parameters
+        """
+        self.model = model
+        self.recursive_model = recursive_model or model
+        self.api_base = api_base
+        self.api_key = api_key
+        self.max_depth = max_depth
+        self.max_iterations = max_iterations
+        self._current_depth = _current_depth
+        self.llm_kwargs = llm_kwargs
+
+        self.repl = REPLExecutor()
+        
+        # Initialize logger (using None for log_file allows automatic generation if needed, but here we likely want per-instance control or global consistency)
+        # Note: In a real library, logging config is usually left to the user, but for this specific request we auto-generate log files.
+        self.logger = get_logger(f"rlm.depth_{_current_depth}", log_file=None) # Passing None to use default or auto-generated logic in logger.py
+
+        # Stats
+        self._llm_calls = 0
+        self._iterations = 0
+
+    def completion(
+        self,
+        query: str = "",
+        context: str = "",
+        **kwargs: Any
+    ) -> str:
+        """
+        Sync wrapper for acompletion.
+
+        Args:
+            query: User query (optional if query is in context)
+            context: Context to process (optional, can pass query here)
+            **kwargs: Additional LiteLLM parameters
+
+        Returns:
+            Final answer string
+
+        Examples:
+            # Standard usage
+            rlm.completion(query="Summarize this", context=document)
+
+            # Query in context (RLM will extract task)
+            rlm.completion(context="Summarize this document: ...")
+
+            # Single string (treat as context)
+            rlm.completion("Process this text and extract dates")
+        """
+        # If only one argument provided, treat it as context
+        if query and not context:
+            context = query
+            query = ""
+
+        return asyncio.run(self.acompletion(query, context, **kwargs))
+
+    async def acompletion(
+        self,
+        query: str = "",
+        context: str = "",
+        **kwargs: Any
+    ) -> str:
+        """
+        Main async completion method.
+
+        Args:
+            query: User query (optional if query is in context)
+            context: Context to process (optional, can pass query here)
+            **kwargs: Additional LiteLLM parameters
+
+        Returns:
+            Final answer string
+
+        Raises:
+            MaxIterationsError: If max iterations exceeded
+            MaxDepthError: If max recursion depth exceeded
+
+        Examples:
+            # Explicit query and context
+            await rlm.acompletion(query="What is this?", context=doc)
+
+            # Query embedded in context
+            await rlm.acompletion(context="Extract all dates from: ...")
+
+            # LLM will figure out the task
+            await rlm.acompletion(context=document_with_instructions)
+        """
+        # If only query provided, treat it as context
+        if query and not context:
+            context = query
+            query = ""
+            
+        self.logger.info(f"Starting completion. Query: {query[:50]}..., Context length: {len(context):,} chars, Depth: {self._current_depth}")
+
+        if self._current_depth >= self.max_depth:
+            raise MaxDepthError(f"Max recursion depth ({self.max_depth}) exceeded")
+
+        # Initialize REPL environment
+        repl_env = self._build_repl_env(query, context)
+
+        # Build initial messages
+        system_prompt = build_system_prompt(len(context), self._current_depth)
+        messages: List[Message] = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": query}
+        ]
+
+        # Main loop
+        for iteration in range(self.max_iterations):
+            self._iterations = iteration + 1
+
+            # Call LLM
+            response = await self._call_llm(messages, **kwargs)
+
+            # Check for FINAL
+            if is_final(response):
+                answer = parse_response(response, repl_env)
+                if answer is not None:
+                    self.logger.info(f"Completion finished. LLM calls: {self._llm_calls}, Iterations: {self._iterations}")
+                    return answer
+
+            # Execute code in REPL
+            try:
+                exec_result = self.repl.execute(response, repl_env)
+                self.logger.info(f"REPL Result: {exec_result[:100]}...")
+            except REPLError as e:
+                exec_result = f"Error: {str(e)}"
+                self.logger.warning(f"REPL Error: {str(e)}")
+            except Exception as e:
+                exec_result = f"Unexpected error: {str(e)}"
+                self.logger.error(f"Unexpected REPL Error: {str(e)}")
+
+            # Add to conversation
+            messages.append({"role": "assistant", "content": response})
+            messages.append({"role": "user", "content": exec_result})
+
+        raise MaxIterationsError(
+            f"Max iterations ({self.max_iterations}) exceeded without FINAL()"
+        )
+
+    async def _call_llm(
+        self,
+        messages: List[Message],
+        **kwargs: Any
+    ) -> str:
+        """
+        Call LLM API.
+
+        Args:
+            messages: Conversation messages
+            **kwargs: Additional parameters (can override model here)
+
+        Returns:
+            LLM response text
+        """
+        self._llm_calls += 1
+
+        # Choose model based on depth
+        default_model = self.model if self._current_depth == 0 else self.recursive_model
+
+        # Allow override via kwargs
+        model = kwargs.pop('model', default_model)
+
+        # Merge kwargs
+        call_kwargs = {**self.llm_kwargs, **kwargs}
+        if self.api_base:
+            call_kwargs['api_base'] = self.api_base
+        if self.api_key:
+            call_kwargs['api_key'] = self.api_key
+
+        # Call LiteLLM
+        # Determine if this is a main or sub LLM call based on depth
+        call_type = "Main LLM" if self._current_depth == 0 else f"Sub LLM (Depth {self._current_depth})"
+        self.logger.debug(f"Calling {call_type}: {model}")
+        
+        response = await litellm.acompletion(
+            model=model,
+            messages=messages,
+            **call_kwargs
+        )
+        self.logger.debug(f"{call_type} Response received ({len(response.choices[0].message.content)} chars)")
+
+        # Extract text
+        return response.choices[0].message.content
+
+    def _build_repl_env(self, query: str, context: str) -> Dict[str, Any]:
+        """
+        Build REPL environment.
+
+        Args:
+            query: User query
+            context: Context string
+
+        Returns:
+            Environment dict
+        """
+        env: Dict[str, Any] = {
+            'context': context,
+            'query': query,
+            'recursive_llm': self._make_recursive_fn(),
+            're': re,  # Whitelist re module
+        }
+        return env
+
+    def _make_recursive_fn(self) -> Any:
+        """
+        Create recursive LLM function for REPL.
+
+        Returns:
+            Async function that can be called from REPL
+        """
+        async def recursive_llm(sub_query: str, sub_context: str) -> str:
+            """
+            Recursively process sub-context.
+
+            Args:
+                sub_query: Query for sub-context
+                sub_context: Sub-context to process
+
+            Returns:
+                Answer from recursive call
+            """
+            if self._current_depth + 1 >= self.max_depth:
+                return f"Max recursion depth ({self.max_depth}) reached"
+
+            # Create sub-RLM with increased depth
+            sub_rlm = RLM(
+                model=self.recursive_model,
+                recursive_model=self.recursive_model,
+                api_base=self.api_base,
+                api_key=self.api_key,
+                max_depth=self.max_depth,
+                max_iterations=self.max_iterations,
+                _current_depth=self._current_depth + 1,
+                **self.llm_kwargs
+            )
+
+            return await sub_rlm.acompletion(sub_query, sub_context)
+
+        # Wrap in sync function for REPL compatibility
+        def sync_recursive_llm(sub_query: str, sub_context: str) -> str:
+            """Sync wrapper for recursive_llm."""
+            # Check if we're in an async context
+            try:
+                loop = asyncio.get_running_loop()
+                # We're in async context, but REPL is sync
+                # Create a new thread to run async code
+                import concurrent.futures
+                with concurrent.futures.ThreadPoolExecutor() as executor:
+                    future = executor.submit(
+                        asyncio.run,
+                        recursive_llm(sub_query, sub_context)
+                    )
+                    return future.result()
+            except RuntimeError:
+                # No running loop, safe to use asyncio.run
+                return asyncio.run(recursive_llm(sub_query, sub_context))
+
+        return sync_recursive_llm
+
+    @property
+    def stats(self) -> Dict[str, int]:
+        """Get execution statistics."""
+        return {
+            'llm_calls': self._llm_calls,
+            'iterations': self._iterations,
+            'depth': self._current_depth,
+        }

--- a/src/rlm_ja/core.py
+++ b/src/rlm_ja/core.py
@@ -169,6 +169,7 @@ class RLM:
             if is_final(response):
                 answer = parse_response(response, repl_env)
                 if answer is not None:
+                    self.logger.info(f"Final answer: {answer[:200]}..." if len(answer) > 200 else f"Final answer: {answer}")
                     self.logger.info(f"Completion finished. LLM calls: {self._llm_calls}, Iterations: {self._iterations}")
                     return answer
 

--- a/src/rlm_ja/logger.py
+++ b/src/rlm_ja/logger.py
@@ -1,0 +1,63 @@
+import logging
+import sys
+import os
+from typing import Optional
+from pathlib import Path
+from datetime import datetime
+
+def get_log_file_path() -> str:
+    """Generate log file path based on main script name and timestamp."""
+    # Get the main script name
+    try:
+        main_script = sys.modules['__main__'].__file__
+        if main_script:
+            script_name = Path(main_script).stem
+        else:
+            script_name = "interactive"
+    except (AttributeError, KeyError):
+        script_name = "unknown"
+
+    # Generate timestamp
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    
+    # Create logs directory if not exists
+    logs_dir = Path("logs")
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    
+    return str(logs_dir / f"{script_name}_{timestamp}.log")
+
+def get_logger(
+    name: str = "rlm_ja",
+    log_file: Optional[str] = None,
+    level: int = logging.INFO
+) -> logging.Logger:
+    logger = logging.getLogger(name)
+    
+    # If logger already has handlers, return it
+    if logger.hasHandlers():
+        return logger
+        
+    logger.setLevel(level)
+    
+    formatter = logging.Formatter(
+        "[%(asctime)s] [%(levelname)s] %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S"
+    )
+    
+    # Console handler
+    console_handler = logging.StreamHandler(sys.stdout)
+    console_handler.setFormatter(formatter)
+    logger.addHandler(console_handler)
+    
+    # File handler
+    if log_file is None:
+        log_file = get_log_file_path()
+        
+    file_path = Path(log_file)
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    
+    file_handler = logging.FileHandler(log_file, encoding='utf-8')
+    file_handler.setFormatter(formatter)
+    logger.addHandler(file_handler)
+        
+    return logger

--- a/src/rlm_ja/parser.py
+++ b/src/rlm_ja/parser.py
@@ -1,0 +1,93 @@
+"""Parse FINAL() and FINAL_VAR() statements from LLM responses."""
+
+import re
+from typing import Optional, Dict, Any
+
+
+def extract_final(response: str) -> Optional[str]:
+    """
+    Extract answer from FINAL() statement.
+
+    Args:
+        response: LLM response text
+
+    Returns:
+        Extracted answer or None if not found
+    """
+    # Look for FINAL("answer") or FINAL('answer')
+    patterns = [
+        r'FINAL\s*\(\s*"""(.*)"""',  # FINAL("""answer""") - triple double quotes
+        r"FINAL\s*\(\s*'''(.*)'''",  # FINAL('''answer''') - triple single quotes
+        r'FINAL\s*\(\s*"([^"]*)"',  # FINAL("answer") - double quotes
+        r"FINAL\s*\(\s*'([^']*)'",  # FINAL('answer') - single quotes
+    ]
+
+    for pattern in patterns:
+        match = re.search(pattern, response, re.DOTALL)
+        if match:
+            return match.group(1).strip()
+
+    return None
+
+
+def extract_final_var(response: str, env: Dict[str, Any]) -> Optional[str]:
+    """
+    Extract answer from FINAL_VAR() statement.
+
+    Args:
+        response: LLM response text
+        env: REPL environment with variables
+
+    Returns:
+        Variable value as string or None if not found
+    """
+    # Look for FINAL_VAR(var_name)
+    match = re.search(r'FINAL_VAR\s*\(\s*(\w+)\s*\)', response)
+    if not match:
+        return None
+
+    var_name = match.group(1)
+
+    # Get variable from environment
+    if var_name in env:
+        value = env[var_name]
+        return str(value)
+
+    return None
+
+
+def is_final(response: str) -> bool:
+    """
+    Check if response contains FINAL() or FINAL_VAR().
+
+    Args:
+        response: LLM response text
+
+    Returns:
+        True if response contains final statement
+    """
+    return 'FINAL(' in response or 'FINAL_VAR(' in response
+
+
+def parse_response(response: str, env: Dict[str, Any]) -> Optional[str]:
+    """
+    Parse response for any final statement.
+
+    Args:
+        response: LLM response text
+        env: REPL environment
+
+    Returns:
+        Final answer or None
+    """
+    # Try FINAL() first
+    answer = extract_final(response)
+    if answer is not None:
+        return answer
+
+    # Try FINAL_VAR()
+    answer = extract_final_var(response, env)
+    if answer is not None:
+        return answer
+
+    return None

--- a/src/rlm_ja/prompts.py
+++ b/src/rlm_ja/prompts.py
@@ -1,0 +1,50 @@
+"""System prompt templates for RLM."""
+
+
+def build_system_prompt(context_size: int, depth: int = 0) -> str:
+    """
+    Build system prompt for RLM.
+
+    Args:
+        context_size: Size of context in characters
+        depth: Current recursion depth
+
+    Returns:
+        System prompt string
+    """
+    # Minimal prompt (paper-style)
+    prompt = f"""あなたはRecursive Language Model(RLM)です。Python REPL環境を通じてコンテキストと対話します。
+
+コンテキストは変数 `context` に格納されています（このプロンプト内ではありません）。サイズ: {context_size:,} 文字。
+
+環境で使用可能なもの:
+- context: str (分析対象のドキュメント)
+- query: str (質問: "{"{"}query{"}"}")
+- recursive_llm(sub_query, sub_context) -> str (サブコンテキストを再帰的に処理する)
+- re: インポート済みの正規表現モジュール (re.findall, re.search などを使用)
+
+質問に答えるためのPythonコードを書いてください。最後の式または print() の出力が表示されます。
+
+例:
+- print(context[:100])  # 最初の100文字を確認
+- errors = re.findall(r'ERROR', context)  # 'ERROR'をすべて検索
+- count = len(errors); print(count)  # カウントして表示
+
+答えが得られたら、FINAL("answer") を使用してください。これは関数ではありません。テキストとして書いてください。
+
+深さ: {depth}"""
+
+    return prompt
+
+
+def build_user_prompt(query: str) -> str:
+    """
+    Build user prompt.
+
+    Args:
+        query: User's question
+
+    Returns:
+        User prompt string
+    """
+    return query

--- a/src/rlm_ja/repl.py
+++ b/src/rlm_ja/repl.py
@@ -1,0 +1,239 @@
+"""Safe REPL executor using RestrictedPython."""
+
+import io
+import sys
+from typing import Dict, Any, Optional
+from RestrictedPython import compile_restricted_exec, safe_globals, limited_builtins, utility_builtins
+from RestrictedPython.Guards import guarded_iter_unpack_sequence, safer_getattr
+from RestrictedPython.PrintCollector import PrintCollector
+
+from .logger import get_logger
+
+class REPLError(Exception):
+    """Error during REPL execution."""
+    pass
+
+
+class REPLExecutor:
+    """Safe Python code executor."""
+
+    def __init__(self, timeout: int = 5, max_output_chars: int = 2000):
+        """
+        Initialize REPL executor.
+
+        Args:
+            timeout: Execution timeout in seconds (not currently enforced)
+            max_output_chars: Maximum characters to return (truncate if longer)
+        """
+        self.timeout = timeout
+        self.max_output_chars = max_output_chars
+        self.logger = get_logger("rlm.repl")
+
+    def execute(self, code: str, env: Dict[str, Any]) -> str:
+        """
+        Execute Python code in restricted environment.
+
+        Args:
+            code: Python code to execute
+            env: Environment with context, query, recursive_llm, etc.
+
+        Returns:
+            String result of execution (stdout or last expression)
+
+        Raises:
+            REPLError: If code execution fails
+        """
+        # Filter out code blocks if present (LLM might wrap code)
+        code = self._extract_code(code)
+
+        if not code.strip():
+            return "No code to execute"
+
+        self.logger.info(f"Executing code: {code[:100]}..." if len(code) > 100 else f"Executing code: {code}")
+
+        # Build restricted globals
+        restricted_globals = self._build_globals(env)
+
+        # Capture stdout
+        old_stdout = sys.stdout
+        sys.stdout = captured_output = io.StringIO()
+
+        try:
+            # Compile with RestrictedPython
+            byte_code = compile_restricted_exec(code)
+
+            if byte_code.errors:
+                raise REPLError(f"Compilation error: {', '.join(byte_code.errors)}")
+
+            # Execute
+            exec(byte_code.code, restricted_globals, env)
+
+            # Get output from stdout
+            output = captured_output.getvalue()
+
+            # Get output from PrintCollector if available
+            if '_print' in env and hasattr(env['_print'], '__call__'):
+                # PrintCollector stores prints in its txt attribute
+                print_collector = env['_print']
+                if hasattr(print_collector, 'txt'):
+                    output += ''.join(print_collector.txt)
+
+            # Check if last line was an expression (try to get its value)
+            # This handles cases like: error_count (should return its value)
+            lines = code.strip().split('\n')
+            if lines:
+                last_line = lines[-1].strip()
+                # If last line is a simple expression (no assignment, no keyword)
+                if last_line and not any(kw in last_line for kw in ['=', 'import', 'def', 'class', 'if', 'for', 'while', 'with']):
+                    try:
+                        # Try to evaluate the last line as expression
+                        result = eval(last_line, restricted_globals, env)
+                        if result is not None:
+                            output += str(result) + '\n'
+                    except:
+                        pass  # Not an expression, ignore
+
+            if not output:
+                return "Code executed successfully (no output)"
+
+            # Truncate output if too long (as per paper: "truncated version of output")
+            if len(output) > self.max_output_chars:
+                truncated = output[:self.max_output_chars]
+                return f"{truncated}\n\n[Output truncated: {len(output)} chars total, showing first {self.max_output_chars}]"
+
+            return output.strip()
+
+        except Exception as e:
+            raise REPLError(f"Execution error: {str(e)}")
+
+        finally:
+            sys.stdout = old_stdout
+
+    def _extract_code(self, text: str) -> str:
+        """
+        Extract code from markdown code blocks if present.
+
+        Args:
+            text: Raw text that might contain code
+
+        Returns:
+            Extracted code
+        """
+        # Check for markdown code blocks
+        if '```python' in text:
+            start = text.find('```python') + len('```python')
+            end = text.find('```', start)
+            if end != -1:
+                return text[start:end].strip()
+
+        if '```' in text:
+            start = text.find('```') + 3
+            end = text.find('```', start)
+            if end != -1:
+                return text[start:end].strip()
+
+        return text
+
+    def _build_globals(self, env: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Build restricted globals for safe execution.
+
+        Args:
+            env: User environment
+
+        Returns:
+            Safe globals dict
+        """
+        restricted_globals = safe_globals.copy()
+        restricted_globals.update(limited_builtins)
+        restricted_globals.update(utility_builtins)
+
+        # Add guards
+        restricted_globals['_iter_unpack_sequence_'] = guarded_iter_unpack_sequence
+        restricted_globals['_getattr_'] = safer_getattr
+        restricted_globals['_getitem_'] = lambda obj, index: obj[index]
+        restricted_globals['_getiter_'] = iter
+        restricted_globals['_print_'] = PrintCollector
+
+        # Add additional safe builtins
+        restricted_globals.update({
+            # Types
+            'len': len,
+            'str': str,
+            'int': int,
+            'float': float,
+            'bool': bool,
+            'list': list,
+            'dict': dict,
+            'tuple': tuple,
+            'set': set,
+            'frozenset': frozenset,
+            'bytes': bytes,
+            'bytearray': bytearray,
+
+            # Iteration
+            'range': range,
+            'enumerate': enumerate,
+            'zip': zip,
+            'map': map,
+            'filter': filter,
+            'reversed': reversed,
+            'iter': iter,
+            'next': next,
+
+            # Aggregation
+            'sorted': sorted,
+            'sum': sum,
+            'min': min,
+            'max': max,
+            'any': any,
+            'all': all,
+
+            # Math
+            'abs': abs,
+            'round': round,
+            'pow': pow,
+            'divmod': divmod,
+
+            # String/repr
+            'chr': chr,
+            'ord': ord,
+            'hex': hex,
+            'oct': oct,
+            'bin': bin,
+            'repr': repr,
+            'ascii': ascii,
+            'format': format,
+
+            # Type checking
+            'isinstance': isinstance,
+            'issubclass': issubclass,
+            'callable': callable,
+            'type': type,
+            'hasattr': hasattr,
+
+            # Constants
+            'True': True,
+            'False': False,
+            'None': None,
+        })
+
+        # Add safe standard library modules
+        # These are read-only and don't allow file/network access
+        import re
+        import json
+        import math
+        from datetime import datetime, timedelta
+        from collections import Counter, defaultdict
+
+        restricted_globals.update({
+            're': re,               # Regex (read-only)
+            'json': json,           # JSON parsing (read-only)
+            'math': math,           # Math functions
+            'datetime': datetime,   # Date parsing
+            'timedelta': timedelta, # Time deltas
+            'Counter': Counter,     # Counting helper
+            'defaultdict': defaultdict,  # Dict with defaults
+        })
+
+        return restricted_globals

--- a/src/rlm_ja/types.py
+++ b/src/rlm_ja/types.py
@@ -1,0 +1,37 @@
+"""Type definitions for RLM."""
+
+from typing import TypedDict, Optional, Any, Callable, Awaitable
+
+
+class Message(TypedDict):
+    """LLM message format."""
+    role: str
+    content: str
+
+
+class RLMConfig(TypedDict, total=False):
+    """Configuration for RLM instance."""
+    model: str
+    recursive_model: Optional[str]
+    api_base: Optional[str]
+    api_key: Optional[str]
+    max_depth: int
+    max_iterations: int
+    temperature: float
+    timeout: int
+
+
+class REPLEnvironment(TypedDict, total=False):
+    """REPL execution environment."""
+    context: str
+    query: str
+    recursive_llm: Callable[[str, str], Awaitable[str]]
+    re: Any  # re module
+
+
+class CompletionResult(TypedDict):
+    """Result from RLM completion."""
+    answer: str
+    iterations: int
+    depth: int
+    llm_calls: int


### PR DESCRIPTION
### 概要
RLMパッケージの日本語ローカライズ版 `rlm_ja` を追加し、実験管理のためのロギング機能を統合しました。

### 変更内容

#### 1. `rlm_ja` パッケージの追加
- `src/rlm` を `src/rlm_ja` としてクローンし、システムプロンプトを日本語化
- エラーメッセージやリターン文は英語のまま維持

#### 2. ロギング機能の統合
- `src/rlm_ja/logger.py` を新規作成
- ログファイルは `logs/{script_name}_{yyyymmdd_hhmmss}.log` として自動生成
- 記録される情報:
  - 処理開始（クエリ、コンテキスト文字数、再帰深度）
  - コード実行イベント（REPL実行内容、結果、エラー）
  - 最終回答
  - 処理完了（LLM呼び出し回数、イテレーション回数）

#### 3. 日本語版サンプルコード
- `examples/ja/basic_usage_ja.py` を追加
- オリジナル版 (`examples/basic_usage.py`) の構造を維持しつつ、ドキュメントとクエリを日本語化
- 標準出力の重複を排除し、ログファイルへの出力に統一

### 関連ファイル
- `src/rlm_ja/` (新規パッケージ)
- `examples/ja/basic_usage_ja.py` (新規サンプル)
- `logs/` (実行時に自動生成)